### PR TITLE
Switch to TSV input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The measurement table must contain the following columns:
 - `analyzer_deg` – analyzer rotation angle (0 means polarization orthogonal to the incoming one)
 - `intensity` – measured signal level
 
-Rows can be added manually via the interface or you can upload a CSV file with these columns.
+Rows can be added manually via the interface or you can upload a TSV file with these columns. The file should use a dot (`.`) as the decimal separator.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -38,9 +38,9 @@ data_edit = st.data_editor(
 )
 st.session_state["meas_df"] = data_edit
 
-uploaded = st.file_uploader("Upload measurement CSV", type="csv")
+uploaded = st.file_uploader("Upload measurement TSV", type="tsv")
 if uploaded is not None:
-    df_up = pd.read_csv(uploaded)
+    df_up = pd.read_csv(uploaded, sep="\t", decimal=".")
     st.session_state["meas_df"] = pd.concat([st.session_state["meas_df"], df_up])
     _rerun()
 


### PR DESCRIPTION
## Summary
- update README to describe TSV upload with dot decimal separator
- switch file upload to TSV and specify separator/decimal settings

## Testing
- `python -m py_compile app.py ellipsometer.py`

------
https://chatgpt.com/codex/tasks/task_e_68448f721a8c8326a5f46dc2c78a46f4