### PR TITLE
Add normalisation per dataset and show angle fits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenWebEllipsometer
 
 Streamlit-based application for fitting thin-film optical parameters from analyzer intensity measurements.
+It now supports setting the polariser angle, intensity offsets and calibration of systematic angle errors.
 
 ## Installation
 
@@ -37,7 +38,15 @@ The measurement table must contain the following columns:
 - `analyzer_deg` – analyzer rotation angle (0 means polarization orthogonal to the incoming one)
 - `intensity` – measured signal level
 
+The application also allows setting the angle between the incidence plane and
+the polarisation direction of the incoming light. This angle can be optimised
+along with a constant offset for the analyzer and incidence angles during
+calibration.
+
 Rows can be added manually via the interface or you can upload a TSV file with these columns. The file should use a dot (`.`) as the decimal separator. The application assumes intensities are normalised, but you may also fit a scaling factor when providing raw detector counts.
+If needed the helper ``normalise_measurements`` can rescale uploaded data. It shifts each
+``(wavelength_nm, incidence_deg)`` pair so the minimum becomes zero and scales
+the range to one.
 
 ## Usage
 
@@ -52,4 +61,11 @@ Each optimised value can have custom lower and upper bounds. These bounds are
 configured in the sidebar next to the corresponding optimisation checkbox. The
 application also provides an **intensity scale** parameter. When fitting raw
 detector counts that are not normalised to the incident power, enable optimisation
-of this scale factor so the model can match the measurement units.
+of this scale factor so the model can match the measurement units. An additional
+offset parameter accounts for detector background.
+
+### Calibration
+
+Use ``calibrate_system`` with a sample of known optical properties to determine
+systematic offsets for the polariser, incidence and analyzer angles. The
+resulting parameters can then be used for subsequent measurements.

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from ellipsometer import (
     Layer,
     ModelParams,
     group_measurements,
+    normalise_measurements,
     predict_dataframe,
     fit_parameters,
 )
@@ -56,6 +57,10 @@ df = st.session_state["meas_df"].copy()
 if df.empty:
     st.stop()
 
+norm = st.sidebar.checkbox("normalise intensities", value=False)
+if norm:
+    df = normalise_measurements(df)
+
 grouped = group_measurements(df)
 st.subheader("Summary data")
 st.dataframe(grouped)
@@ -69,6 +74,14 @@ st.sidebar.header("Model parameters")
 n_before = st.sidebar.number_input("n before film", value=1.0)
 scale_val = st.sidebar.number_input("intensity scale", value=1.0)
 opt_scale = st.sidebar.checkbox("fit intensity scale", value=False)
+offset_val = st.sidebar.number_input("intensity offset", value=0.0)
+opt_offset = st.sidebar.checkbox("fit intensity offset", value=False)
+pol_angle = st.sidebar.number_input("polariser angle deg", value=45.0)
+opt_pol = st.sidebar.checkbox("fit polariser angle", value=False)
+inc_off = st.sidebar.number_input("incidence offset deg", value=0.0)
+opt_inc_off = st.sidebar.checkbox("fit incidence offset", value=False)
+an_off = st.sidebar.number_input("analyser offset deg", value=0.0)
+opt_an_off = st.sidebar.checkbox("fit analyser offset", value=False)
 
 if "layers" not in st.session_state:
     st.session_state["layers"] = []
@@ -136,15 +149,39 @@ params = ModelParams(
     n_sub=n_sub,
     k_sub=k_sub,
     intensity_scale=scale_val,
+    intensity_offset=offset_val,
+    polarizer_deg=pol_angle,
+    incidence_offset_deg=inc_off,
+    analyzer_offset_deg=an_off,
 )
 
 optimise["sub_n"] = opt_n_sub
 optimise["sub_k"] = opt_k_sub
 optimise["scale"] = opt_scale
+optimise["offset"] = opt_offset
+optimise["polarizer_deg"] = opt_pol
+optimise["inc_offset"] = opt_inc_off
+optimise["an_offset"] = opt_an_off
 if opt_scale:
     scale_min = st.sidebar.number_input("scale min", value=0.0)
     scale_max = st.sidebar.number_input("scale max", value=100000.0)
     bounds["scale"] = (scale_min, scale_max)
+if opt_offset:
+    off_min = st.sidebar.number_input("offset min", value=-1000.0)
+    off_max = st.sidebar.number_input("offset max", value=1000.0)
+    bounds["offset"] = (off_min, off_max)
+if opt_pol:
+    pol_min = st.sidebar.number_input("pol angle min", value=0.0)
+    pol_max = st.sidebar.number_input("pol angle max", value=90.0)
+    bounds["polarizer_deg"] = (pol_min, pol_max)
+if opt_inc_off:
+    inc_min = st.sidebar.number_input("inc offset min", value=-10.0)
+    inc_max = st.sidebar.number_input("inc offset max", value=10.0)
+    bounds["inc_offset"] = (inc_min, inc_max)
+if opt_an_off:
+    an_min = st.sidebar.number_input("an offset min", value=-10.0)
+    an_max = st.sidebar.number_input("an offset max", value=10.0)
+    bounds["an_offset"] = (an_min, an_max)
 
 if st.button("Start optimisation"):
     fitted, rmse = fit_parameters(grouped, params, optimise, bounds)
@@ -155,6 +192,11 @@ if st.button("Start optimisation"):
         st.write(f"layer {i + 1} thickness [nm]: {layer.thickness_nm:.2f}")
     st.write(f"substrate n: {fitted.n_sub:.4f}")
     st.write(f"substrate k: {fitted.k_sub:.4f}")
+    st.write(f"intensity scale: {fitted.intensity_scale:.4f}")
+    st.write(f"intensity offset: {fitted.intensity_offset:.4f}")
+    st.write(f"polariser angle [deg]: {fitted.polarizer_deg:.2f}")
+    st.write(f"incidence offset [deg]: {fitted.incidence_offset_deg:.2f}")
+    st.write(f"analyser offset [deg]: {fitted.analyzer_offset_deg:.2f}")
     st.write(f"RMSE: {rmse:.6f}")
 
     preds = predict_dataframe(grouped, fitted)


### PR DESCRIPTION
## Summary
- normalize intensities per incidence/wavelength pair
- show scale, offset and angle parameters after optimisation
- mention per-group normalisation in the docs

## Testing
- `python -m py_compile ellipsometer.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844aaa76e4c83269170e14280a1043f